### PR TITLE
feat(getdatabyquery()): added new argument 'queryColumn'

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ All Data functions
 ````js
 await chatbot.getData(sheetName);
 
-await chatbot.getDatabyQuery(sheetName, query);
+await chatbot.getDatabyQuery(sheetName, query, queryColumn='name'||'response');
 
 await chatbot.authorize({email, ipaddress, deviceDetails, location});
 

--- a/index.js
+++ b/index.js
@@ -75,8 +75,8 @@ const responseTypes = require("./libs/responseFunctions");
       }
     }
     
-    getDatabyQuery(sheetName, query){
-      return this._extensionData.getDatabyQuery(sheetName, query);
+    getDatabyQuery(sheetName, query, queryColumn="name"){
+      return this._extensionData.getDatabyQuery(sheetName, query, queryColumn);
     }
 
     //Realtime Database

--- a/libs/data.js
+++ b/libs/data.js
@@ -34,14 +34,21 @@ module.exports = class Data {
           }
     }
 
-    async getDatabyQuery(sheetName, query){
+    async getDatabyQuery(sheetName, query, queryColumn='name'){
         if(!sheetName || !query){
             throw new Error('\x1b[31m Sheet Name and query required! \x1b[0m');
           } else{
         const snapshot = await this._getDataExtension(sheetName);
         for (const i in snapshot){
-            if (snapshot[i].name == query) {
+            if(queryColumn == 'name'){
+            if (snapshot[i][queryColumn] == query) {
                 return snapshot[i]
+            }} else {
+                for (const j in snapshot[i].response){
+                    if (snapshot[i].response[j].text.includes(query)) {
+                        return snapshot[i]
+                    }
+                }
             }
         }
         return null


### PR DESCRIPTION
Added new argument to define query search between name and response

getDatabyQuery() can now takes in three arguments: 'sheetName', 'query' and 'queryColumn'. The
queryColumn is set to 'name' by default but can also accept the string 'response' to change the
query search from name to the response.